### PR TITLE
fix(chezmoi): seed data.xdg at init so first apply works on fresh hosts

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -1,0 +1,17 @@
+{{/*
+Source-root init template. `chezmoi init` renders this to
+~/.config/chezmoi/chezmoi.toml before any `apply` runs, seeding `.xdg.*` so
+templates that reference it (e.g. dot_config/wget/wgetrc.tmpl) resolve on the
+very first apply. On subsequent applies, the managed
+dot_config/chezmoi/private_chezmoi.toml.tmpl overwrites this file with the full
+config (adds [diff] and [merge]) — intentionally narrow here so the init
+template does only what init can't defer.
+
+Cross-platform: XDG_* wins when set (Linux, or macOS users who export it); else
+falls back to XDG-spec defaults under $HOME (typical macOS).
+*/ -}}
+[data.xdg]
+    cache  = {{ env "XDG_CACHE_HOME"  | default (joinPath .chezmoi.homeDir ".cache")         | quote }}
+    config = {{ env "XDG_CONFIG_HOME" | default (joinPath .chezmoi.homeDir ".config")        | quote }}
+    data   = {{ env "XDG_DATA_HOME"   | default (joinPath .chezmoi.homeDir ".local" "share") | quote }}
+    state  = {{ env "XDG_STATE_HOME"  | default (joinPath .chezmoi.homeDir ".local" "state") | quote }}


### PR DESCRIPTION
## Summary

Adds a source-root `.chezmoi.toml.tmpl` that seeds `data.xdg.{cache,config,data,state}` at `chezmoi init` time, before the first `apply` runs. This unblocks templates that reference `.xdg.*` on a fresh host.

## Why

`dot_config/chezmoi/private_chezmoi.toml.tmpl` already defines `[data.xdg]`, but it's a *managed* file — it only exists after the first `apply`. Templates that depend on `.xdg.*` (currently `dot_config/wget/wgetrc.tmpl:1`, via `{{ .xdg.cache }}`) fail on a brand-new machine because the data key isn't populated yet. Classic bootstrap ordering problem: the config that produces the data is itself produced by the thing that needs the data.

Chezmoi resolves this via the source-root `.chezmoi.toml.tmpl`, which it renders to `~/.config/chezmoi/chezmoi.toml` during `init` — before any `apply`.

## Design notes

The init template is narrow by design: it only seeds `[data.xdg]`. `[diff]` and `[merge]` stay in the managed `private_chezmoi.toml.tmpl`, which overwrites the init output on the first apply. Rationale: keep the init template limited to what init *must* provide; let the managed file own everything else so there's a single source of truth post-bootstrap.

For cross-platform behavior, `env "XDG_*" | default (joinPath .chezmoi.homeDir ...)` respects `XDG_*` when exported (Linux, or macOS users who set them), otherwise falls back to XDG-spec defaults under `\$HOME`. This differs from the managed template, which assumes `XDG_*` is set; the init template can't assume that on a fresh host.

One divergence risk worth calling out: the two templates now both define `[data.xdg]` with slightly different logic (init has fallbacks, managed does not). If `XDG_*` is unset at apply time, the managed file will write empty strings and break `.xdg.*` consumers. Worth a follow-up to unify them — either by giving the managed template the same fallback, or by sourcing `XDG_*` defaults earlier in the shell env.