### PR TITLE
Install CLI tools on Linux via cargo install

### DIFF
--- a/.chezmoiscripts/run_once_after_99_misc.sh
+++ b/.chezmoiscripts/run_once_after_99_misc.sh
@@ -3,3 +3,9 @@
 mkdir -p "${XDG_STATE_HOME:-$HOME/.state}/zsh/"
 bat cache --build
 tldr --update
+
+# Generate fzf zsh integration — the zshrc sources $ZDOTDIR/fzf-completion.zsh
+# conditionally, so this file defines the keybindings and completion.
+ZDOTDIR="${ZDOTDIR:-${XDG_CONFIG_HOME:-$HOME/.config}/zsh}"
+mkdir -p "$ZDOTDIR"
+fzf --zsh >"$ZDOTDIR/fzf-completion.zsh"

--- a/.chezmoiscripts/run_once_before_00_init.sh.tmpl
+++ b/.chezmoiscripts/run_once_before_00_init.sh.tmpl
@@ -191,7 +191,6 @@ echo "📦  Installing Rust CLIs via cargo install"
 cargo install --locked \
     bat \
     broot \
-    dog \
     du-dust \
     eza \
     fd-find \
@@ -208,6 +207,20 @@ if ! command -v fzf &>/dev/null; then
         | grep -m1 '"tag_name":' | sed 's/.*"v\(.*\)".*/\1/')
     curl -fsSL "https://github.com/junegunn/fzf/releases/download/v${FZF_VERSION}/fzf-${FZF_VERSION}-linux_amd64.tar.gz" \
         | tar -xz -C "$HOME/.local/bin"
+fi
+
+# dog (DNS client) isn't on crates.io; fetch the upstream release. Only v0.1.0
+# exists — the project has been dormant since 2020.
+if ! command -v dog &>/dev/null; then
+    echo "📦  Installing dog"
+    command -v unzip &>/dev/null || sudo apt-get install -y -qq unzip
+    mkdir -p "$HOME/.local/bin"
+    tmp=$(mktemp -d)
+    curl -fsSL "https://github.com/ogham/dog/releases/download/v0.1.0/dog-v0.1.0-x86_64-unknown-linux-gnu.zip" \
+        -o "$tmp/dog.zip"
+    unzip -q "$tmp/dog.zip" -d "$tmp"
+    install -m 0755 "$tmp/bin/dog" "$HOME/.local/bin/dog"
+    rm -rf "$tmp"
 fi
 
 # shellcheck disable=1054,1083

--- a/.chezmoiscripts/run_once_before_00_init.sh.tmpl
+++ b/.chezmoiscripts/run_once_before_00_init.sh.tmpl
@@ -49,6 +49,7 @@ brew "coreutils"
 brew "crane"
 brew "curl"
 brew "dive"
+brew "dog"
 brew "dust"
 brew "eza"
 brew "fd"
@@ -169,6 +170,45 @@ EOF
 
 echo "Package installation completed."
 
+
+# shellcheck disable=1054,1083
+{{ end -}}
+
+# shellcheck disable=1054,1083
+{{- if eq .chezmoi.os "linux" }}
+# Linux has no brew; bootstrap Rust and `cargo install` the CLIs that mirror
+# the macOS Brewfile. `cargo install` is idempotent — re-runs skip crates
+# already at the installed version.
+if ! command -v cargo &>/dev/null; then
+    echo "🦀  Installing Rust toolchain"
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+        | sh -s -- --default-toolchain stable --no-modify-path -y
+fi
+# shellcheck disable=SC1091
+source "$HOME/.cargo/env"
+
+echo "📦  Installing Rust CLIs via cargo install"
+cargo install --locked \
+    bat \
+    broot \
+    dog \
+    du-dust \
+    eza \
+    fd-find \
+    git-delta \
+    ripgrep \
+    tealdeer \
+    zoxide
+
+# fzf is Go (not on crates.io); fetch the upstream release into ~/.local/bin.
+if ! command -v fzf &>/dev/null; then
+    echo "📦  Installing fzf"
+    mkdir -p "$HOME/.local/bin"
+    FZF_VERSION=$(curl -fsSL https://api.github.com/repos/junegunn/fzf/releases/latest \
+        | grep -m1 '"tag_name":' | sed 's/.*"v\(.*\)".*/\1/')
+    curl -fsSL "https://github.com/junegunn/fzf/releases/download/v${FZF_VERSION}/fzf-${FZF_VERSION}-linux_amd64.tar.gz" \
+        | tar -xz -C "$HOME/.local/bin"
+fi
 
 # shellcheck disable=1054,1083
 {{ end -}}


### PR DESCRIPTION
## Summary
- On macOS the Brewfile already covers these tools; on Linux there's no brew, so `run_once_before_00_init.sh.tmpl` now bootstraps rustup and `cargo install --locked`s the Rust CLIs that mirror the Brewfile (bat, broot, dust, eza, fd, delta, ripgrep, tealdeer, zoxide).
- `dog` (DNS client) isn't on crates.io — the `dog` crate there is unrelated and has no binaries. It's fetched from ogham/dog's single v0.1.0 release zip instead. `fzf` (Go) is also a GitHub release.
- `brew "dog"` added to the macOS Brewfile so both platforms provide it.
- `run_once_after_99_misc.sh` now emits `$ZDOTDIR/fzf-completion.zsh` via `fzf --zsh` so the zshrc's conditional source has something to read regardless of how fzf got installed.

## Test plan
- [x] Linux workspace: fresh `chezmoi init --apply https://github.com/chagui/dotfiles` succeeds end-to-end; `bat`, `broot`, `dog`, `dust`, `eza`, `fd`, `delta`, `rg`, `tldr`, `zoxide`, `fzf` all resolve on PATH after apply.
- [x] Linux: `fzf` keybindings (ctrl-r, ctrl-t) work in a new zsh — confirms `fzf-completion.zsh` was generated.
- [x] macOS: `brew bundle` still succeeds with the added `dog` entry; no regression on the existing tools.
- [x] Re-apply is a no-op (cargo skips already-installed crates; `command -v` guards on fzf/dog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)