### PR TITLE
feat(ghostty): try Ghostty

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,6 +46,18 @@ repos:
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
 
+  # Skips silently if `ghostty` is not on PATH (e.g. on Linux dev boxes).
+  # Note: validates the .tmpl as-is. The file currently has no Go-template
+  # syntax, so chezmoi passes it through unchanged. If templating is added
+  # later, render via `chezmoi execute-template` before validating.
+  - repo: local
+    hooks:
+      - id: ghostty-validate-config
+        name: validate ghostty config
+        entry: bash -c 'command -v ghostty >/dev/null || exit 0; for f in "$@"; do ghostty +validate-config --config-file="$f" || exit 1; done' --
+        language: system
+        files: '^dot_config/ghostty/.*\.tmpl$'
+
   - repo: meta
     hooks:
       - id: check-hooks-apply

--- a/dot_config/ghostty/config.tmpl
+++ b/dot_config/ghostty/config.tmpl
@@ -1,0 +1,44 @@
+# Window
+background-opacity = 0.7
+background-blur-radius = 20
+macos-titlebar-style = tabs
+window-padding-x = 6
+window-padding-y = 6
+# Manually resize once (green button, or Rectangle/Spectacle); the layout
+# is preserved across launches by window-save-state.
+window-save-state = always
+
+# Behavior
+copy-on-select = clipboard
+mouse-hide-while-typing = true
+
+# Send Esc-prefix on left option so emacs-style bindings reach the shell
+# (e.g. fzf-cd-widget on Alt+C). Right option still composes accents.
+macos-option-as-alt = left
+
+# Keybindings
+# Most defaults already match tmux muscle memory:
+#   Cmd+T = new tab, Cmd+W = close, Cmd+D = split right,
+#   Cmd+Shift+D = split down, Cmd+1-9 = goto tab
+
+# Navigate splits with Cmd+Arrow (default is Cmd+Alt+Arrow)
+keybind = super+left=goto_split:left
+keybind = super+down=goto_split:bottom
+keybind = super+up=goto_split:top
+keybind = super+right=goto_split:right
+
+# Resize splits with Cmd+Shift+Arrow (default is Cmd+Ctrl+Arrow)
+keybind = super+shift+left=resize_split:left,10
+keybind = super+shift+down=resize_split:down,10
+keybind = super+shift+up=resize_split:up,10
+keybind = super+shift+right=resize_split:right,10
+
+# Zoom split with Cmd+Z (default is Cmd+Shift+Enter)
+keybind = super+z=toggle_split_zoom
+
+# Rename tab with Cmd+, (like tmux rename-window)
+keybind = super+comma=set_tab_title:
+
+# Cycle tabs with Ctrl+Tab / Ctrl+Shift+Tab
+keybind = ctrl+tab=next_tab
+keybind = ctrl+shift+tab=previous_tab


### PR DESCRIPTION
## Summary

Experimenting with Ghostty: native tabs and splits, embedded fonts, translucent blurred background, and emacs-style Alt key handling on macOS.

What this PR adds:

- **Initial Ghostty config** (`dot_config/ghostty/config.tmpl`): translucent background with macOS blur, tab-style titlebar, copy-on-select, embedded JetBrains Mono Nerd Font, stock dark theme. `window-save-state = always` retains size/position across launches.
- **Native tabs and splits** keybindings: `Cmd+Arrow` for split navigation, `Cmd+Shift+Arrow` for resize, `Cmd+Z` for split zoom, `Ctrl+Tab` cycles tabs, `Cmd+,` renames the current tab.
- **`macos-option-as-alt = left`** so emacs-style `\e<key>` bindings reach the shell — `Alt+C` (fzf-cd-widget) was silently inert before. Right option still composes accents.
- **Pre-commit hook** runs `ghostty +validate-config` on `dot_config/ghostty/*.tmpl` to catch typos in keybind actions like `open_url` (not a real Ghostty action) at commit time, instead of at next reload.

Companion branch extracted from this one: `chagui/misc/ghostty-followups` — adds a Claude `WebFetch` permission for ghostty.org docs and a tmux split-direction tweak. Both bits arose during the Ghostty experiment but are independent of the Ghostty config itself.

## Test plan

- [ ] `chezmoi apply`; reload Ghostty (`Cmd+Shift+,`) — no validate errors
- [ ] Background transparency + blur visible (window not in fullscreen)
- [ ] `^T` / `^R` / `Alt+C` trigger fzf file / history / cd-widget
- [ ] Right option still composes (e.g. `option+e e` → `é`)
- [ ] `Cmd+D` splits, `Cmd+Arrow` navigates between splits, `Cmd+Shift+Arrow` resizes
- [ ] Pre-commit hook fails when an invalid ghostty key is added to the config

🤖 Generated with [Claude Code](https://claude.com/claude-code)