### PR TITLE
chore: misc tweaks (tmux splits, fzf externals, ghostty webfetch)

### DIFF
--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -416,6 +416,7 @@
       "WebFetch(domain:docs.gitlab.com)",
       "WebFetch(domain:graphite.dev)",
       "WebFetch(domain:handbook.gitlab.com)",
+      "WebFetch(domain:ghostty.org)",
       "WebFetch(domain:lazy.folke.io)",
       "WebFetch(domain:neovim.io)",
       "WebFetch(domain:www.jetbrains.com)",

--- a/dot_config/tmux/tmux.conf.tmpl
+++ b/dot_config/tmux/tmux.conf.tmpl
@@ -24,9 +24,9 @@ bind r source-file ~/.config/tmux/tmux.conf
 unbind c
 bind t new-window
 unbind '"'
-bind h split-window -h -c '#{pane_current_path}'
+bind v split-window -h -c '#{pane_current_path}'
 unbind %
-bind v split-window -v -c '#{pane_current_path}'
+bind h split-window -v -c '#{pane_current_path}'
 
 #bind-key h select-pane -L
 bind-key j select-pane -D


### PR DESCRIPTION
## Summary

Grab-bag branch of three small, independent changes:

- **refactor(zsh):** source upstream fzf `completion.zsh` and `key-bindings.zsh` via chezmoi externals instead of bundling local copies, so they refresh weekly. Also renames the existing external to `fzf-completions.zsh` (plural) for consistency.
- **feat(claude):** allowlist `WebFetch(domain:ghostty.org)` so Claude can pull Ghostty docs without prompting.
- **fix(tmux):** swap the `h`/`v` split bindings so they match the direction they actually produce — `v` now creates a vertical split (left/right panes) and `h` a horizontal one (top/bottom). Previous bindings were inverted.

Each commit stands on its own; could be split if reviewer prefers.

## Test plan

- [ ] `chezmoi diff` shows expected changes for `.chezmoiexternal.toml`, `dot_claude/settings.json`, `dot_config/tmux/tmux.conf.tmpl`, `dot_config/zsh/dot_zshrc.tmpl`
- [ ] After apply: new `~/.config/zsh/key-bindings.zsh` exists and is sourced by zshrc; `Ctrl-T` / `Ctrl-R` / `Alt-C` fzf bindings still work
- [ ] In tmux: `prefix v` opens a left/right split, `prefix h` opens a top/bottom split
- [ ] Claude Code no longer prompts on `WebFetch` to `ghostty.org`

🤖 Generated with [Claude Code](https://claude.com/claude-code)