### PR TITLE
feat(terminal): align tmux + claude with code.claude.com recommendations

### DIFF
--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -17,6 +17,15 @@
     "command": "~/.claude/statusline.sh",
     "padding": 1
   },
+  "hooks": {
+    "Notification": [
+      {
+        "hooks": [
+          { "type": "command", "command": "afplay /System/Library/Sounds/Glass.aiff" }
+        ]
+      }
+    ]
+  },
   "permissions": {
     "allow": [
       "Bash(awk:*)",

--- a/dot_config/tmux/tmux.conf.tmpl
+++ b/dot_config/tmux/tmux.conf.tmpl
@@ -50,6 +50,13 @@ set -sa terminal-overrides ",xterm*:Tc"
 #set -ag terminal-overrides ',*:Setulc=\E[58::2::%p1%{65536}%/%d::%p1%{256}%/%{255}%&%d::%p1%{255}%&%d%;m'  # colored underscores
 #set -ag terminal-overrides ",alacritty:RGB"
 
+# Claude Code: pass through OSC sequences (notifications, progress bar) and
+# distinguish Shift+Enter from plain Enter so newline insertion works.
+# https://code.claude.com/docs/en/terminal-config#configure-tmux
+set -g allow-passthrough on
+set -s extended-keys on
+set -as terminal-features 'xterm*:extkeys'
+
 # index from 1 instead of 0
 set -g base-index 1
 setw -g pane-base-index 1


### PR DESCRIPTION
## Summary

Audited the dotfiles against [code.claude.com/docs/en/terminal-config](https://code.claude.com/docs/en/terminal-config). Two gaps, both addressed here:

- **tmux** was missing the three lines Claude Code needs to behave correctly when run inside tmux (the primary path here, since Alacritty auto-launches tmux and Ghostty is also typically used with tmux). Without them, Shift+Enter submits instead of inserting a newline, and desktop notifications + the progress bar get swallowed by tmux before reaching Ghostty.
- **`dot_claude/settings.json`** had no `Notification` hook. Ghostty already forwards Claude Code's desktop notification, but adding an audible cue (`Glass.aiff`) makes it harder to miss when the terminal is not in focus.

Ghostty's `macos-option-as-alt = left` and native Shift+Enter were already correct, so no changes there.

## Out of scope

- Alacritty `Shift+Enter` binding via `/terminal-setup`: redundant — Alacritty here always launches tmux, so the tmux fix covers it.
- Fullscreen mode, Vim editor mode, custom themes: personal-preference toggles, not "recommendations" per the docs.

## Test plan

- [ ] `chezmoi diff` shows only the additions in this PR
- [ ] After `chezmoi apply` + `tmux source-file ~/.config/tmux/tmux.conf`:
  - [ ] Inside tmux, `claude` prompt: Shift+Enter inserts a newline (does not submit)
  - [ ] When Claude finishes a task or asks for a permission prompt, Ghostty shows a desktop notification AND `Glass.aiff` plays
- [ ] `tmux show-options -g allow-passthrough` returns `on`
- [ ] `tmux show-options -s extended-keys` returns `on`

🤖 Generated with [Claude Code](https://claude.com/claude-code)