### PR TITLE
feat(nvim): add vim.ui2, undotree, and restart keymap for v0.12

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,3 @@
+[default.extend-words]
+# noice is a Neovim plugin name, not a typo
+noice = "noice"

--- a/dot_config/nvim/init.lua
+++ b/dot_config/nvim/init.lua
@@ -1,3 +1,15 @@
+-- vim ui2
+require("vim._core.ui2").enable({
+    enable = true,
+    msg = {
+        target = "cmd", -- options: cmd(classic), msg(folke/noice.nvim-style popup)
+        pager = { height = 1 },
+        msg = { height = 0.5, timeout = 4500 },
+        dialog = { height = 0.5 },
+        cmd = { height = 0.5 },
+    },
+})
+
 require("user.options")
 
 -- When running in VSCode, avoid plugins that duplicate VSCode features

--- a/dot_config/nvim/lua/plugins/editor.lua
+++ b/dot_config/nvim/lua/plugins/editor.lua
@@ -43,6 +43,13 @@ return {
         },
     },
     {
+        "mbbill/undotree",
+        cmd = "UndotreeToggle",
+        keys = {
+            { "<leader>u", "<cmd>UndotreeToggle<cr>", desc = "Undotree toggle" },
+        },
+    },
+    {
         "akinsho/git-conflict.nvim",
         version = "*",
         event = "BufReadPre",

--- a/dot_config/nvim/lua/user/keymaps.lua
+++ b/dot_config/nvim/lua/user/keymaps.lua
@@ -38,6 +38,11 @@ utils.inoremap("kj", "<Esc>")
 utils.nmap("∆", "<Cmd>move .+1<CR>==")
 utils.nmap("˚", "<Cmd>move .-2<CR>==")
 
+-- Restart
+vim.keymap.set("n", "<leader>re", "<cmd>restart<cr>", {
+    desc = "Restart Neovim (:restart)",
+})
+
 -- Git hotkeys
 utils.map("<C-g>f", "<Cmd>GFiles<CR>")
 utils.nmap("<leader>gs", "<Cmd>Git<CR>", { desc = "Git status" })


### PR DESCRIPTION
## Summary

- Enable `vim._core.ui2` (new in Neovim 0.12) with `cmd` target and custom pane heights
- Add `mbbill/undotree` via lazy.nvim, bound to `<leader>u`
- Add `<leader>re` keymap for `:restart`
- Add `.typos.toml` to allowlist `noice` (Neovim plugin name)

## Test plan

- [x] Open Neovim and confirm no startup errors from `vim._core.ui2`
- [x] Press `<leader>u` to toggle undotree panel
- [x] Press `<leader>re` to restart Neovim
- [x] Confirm messages render via cmd line (not floating window)

🤖 Generated with [Claude Code](https://claude.com/claude-code)